### PR TITLE
Add : 챌린지 홈 쪽 API 연동, 토큰 쿠키 활용하도록 수정, 자동 로그인 구현, 토큰 재발급 구현

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -24,29 +24,7 @@ export const loginApi = (email, password) => {
 };
 
 // 토큰 재발급 API
-export const refreshApi = (refreshToken) => {
-  console.log('토큰 재발급 API 요청:', {
-    refreshToken: refreshToken ? '***' : '없음',
-  });
-  return api
-    .post('/auth/refresh', { refreshToken })
-    .then((response) => {
-      console.log('토큰 재발급 API 응답 데이터:', {
-        status: response.data.status,
-        message: response.data.message,
-        data: response.data.data,
-      });
-      return response;
-    })
-    .catch((error) => {
-      console.log('토큰 재발급 API 에러 응답 데이터:', {
-        status: error.response?.data?.status,
-        message: error.response?.data?.message,
-        data: error.response?.data?.data,
-      });
-      throw error;
-    });
-};
+export const refreshApi = () => api.post('/auth/refresh');
 
 // 회원가입 API
 export const signup = async (formData) => {

--- a/src/api/challenge/challenge.js
+++ b/src/api/challenge/challenge.js
@@ -1,0 +1,15 @@
+import api from '../instance.js';
+
+/** 챌린지 요약 */
+export const getChallengeSummary = () =>
+    api.get('/challenge/summary')
+        .then(res => res.data?.data)           // CommonResponseDTO<T> → T만 반환
+        .catch(err => { throw err; });
+
+/** 챌린지 리스트
+ * @param {{ type?: 'PERSONAL'|'GROUP'|'COMMON', status?: 'RECRUITING'|'IN_PROGRESS'|'CLOSED'|'COMPLETED', participating?: boolean }} params
+ */
+export const getChallengeList = (params = {}) =>
+    api.get('/challenge/list', { params })
+        .then(res => res.data?.data)           // List<ChallengeListResponseDTO>
+        .catch(err => { throw err; });

--- a/src/api/coin/coin.js
+++ b/src/api/coin/coin.js
@@ -1,0 +1,14 @@
+import api from '../instance';
+
+/**
+ * 월별 누적 포인트 조회
+ * 백엔드: GET /api/coin/monthly?year=YYYY&month=MM
+ * 응답: CommonResponseDTO<{ monthlyCumulativeAmount: number, ... }>
+ */
+export const getMonthlyPoints = ({ year, month }) =>
+    api
+        .get('/coin/monthly', { params: { year, month } })
+        .then((res) => res.data?.data) // { monthlyCumulativeAmount, ... }
+        .catch((err) => {
+            throw err;
+        });

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,2 +1,4 @@
 export * from './authApi.js';
 export * from './finance/deposit.js';
+export * from './challenge/challenge.js';
+export * from './coin/coin.js';

--- a/src/api/instance.js
+++ b/src/api/instance.js
@@ -1,73 +1,66 @@
 import axios from 'axios';
-import Cookies from 'js-cookie';
 import { useAuthStore } from '@/stores/auth';
 
 const instance = axios.create({
-  baseURL: '/api',
-  headers: {
-    'Content-Type': 'application/json',
-    Accept: 'application/json',
-  },
+    baseURL: '/api',          // Vite 프록시 경유
+    withCredentials: true,    // ★ 쿠키 자동 저장/전송
+    headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+    },
 });
 
 // ===== 요청 인터셉터: 액세스 토큰 헤더 주입 =====
 instance.interceptors.request.use((config) => {
-  const auth = useAuthStore();
-  if (auth?.accessToken) {
-    config.headers.Authorization = `Bearer ${auth.accessToken}`;
-  }
-  return config;
+    const auth = useAuthStore();
+    if (auth?.accessToken) {
+        config.headers.Authorization = `Bearer ${auth.accessToken}`;
+    }
+    return config;
 });
 
-// ===== 응답 인터셉터: 401 처리 & 리프레시 =====
-let isRefreshing = false;
-let refreshPromise = null;
-
+// ===== 응답 인터셉터: 로그인/재발급 응답 헤더에서 AT 저장 =====
 instance.interceptors.response.use(
-  (res) => res,
-  async (error) => {
-    const auth = useAuthStore();
-    const original = error.config;
+    (res) => {
+        const authHeader = res.headers?.authorization;
+        if (authHeader?.startsWith('Bearer ')) {
+            const at = authHeader.slice(7);
+            const auth = useAuthStore();
+            auth.setTokens({ accessToken: at }); // RT는 httpOnly 쿠키 → JS에서 다루지 않음
+        }
+        return res;
+    },
+    async (error) => {
+        const auth = useAuthStore();
+        const original = error.config;
 
-    // 로그인/리프레시 호출 자체의 401은 바로 실패로
-    const isAuthCall =
-      original?.url?.includes('/auth/login') ||
-      original?.url?.includes('/auth/refresh');
+        // 로그인/리프레시 자체 실패는 패스
+        const isAuthCall =
+            original?.url?.includes('/auth/login') ||
+            original?.url?.includes('/auth/refresh');
 
-    if (error.response?.status === 401 && !isAuthCall) {
-      // 리프레시 토큰이 없으면 로그아웃
-      const hasRT = !!Cookies.get('refreshToken');
-      if (!hasRT) {
-        auth.logout();
+        // 401이면 리프레시 시도 → 성공 시 원요청 재시도
+        if (error.response?.status === 401 && !isAuthCall) {
+            try {
+                const r = await instance.post('/auth/refresh'); // 바디 없음, 쿠키 자동 전송
+                const authHeader = r.headers?.authorization;
+                if (!authHeader?.startsWith('Bearer ')) {
+                    throw new Error('No Authorization header in refresh response');
+                }
+                const newAT = authHeader.slice(7);
+                auth.setTokens({ accessToken: newAT });
+
+                // 원 요청 토큰 갱신 후 재시도
+                original.headers = original.headers || {};
+                original.headers.Authorization = `Bearer ${newAT}`;
+                return instance(original);
+            } catch (e) {
+                auth.logout(); // RT 만료/불일치 등 → 세션 종료
+            }
+        }
+
         return Promise.reject(error);
-      }
-
-      // 동시에 여러 요청이 401이면 한 번만 refresh
-      if (!isRefreshing) {
-        isRefreshing = true;
-        refreshPromise = auth
-          .refreshTokens()
-          .catch((e) => {
-            auth.logout();
-            throw e;
-          })
-          .finally(() => {
-            isRefreshing = false;
-          });
-      }
-
-      try {
-        const newAccess = await refreshPromise;
-        // 새 토큰으로 Authorization 갱신 후 재시도
-        original.headers.Authorization = `Bearer ${newAccess}`;
-        return instance(original);
-      } catch (e) {
-        return Promise.reject(e);
-      }
     }
-
-    return Promise.reject(error);
-  }
 );
 
 export default instance;

--- a/src/components/challenge/ChallengeStatsSwiper.vue
+++ b/src/components/challenge/ChallengeStatsSwiper.vue
@@ -1,27 +1,22 @@
 <template>
   <Swiper
-    :modules="[Pagination, Autoplay]"
-    :slides-per-view="1"
-    :space-between="20"
-    :pagination="{
-      clickable: true,
-    }"
-    :loop="true"
-    :autoplay="{
-      delay: 3000,
-      disableOnInteraction: false,
-    }"
-    class="stats-swiper"
+      :modules="[Pagination, Autoplay]"
+      :slides-per-view="1"
+      :space-between="20"
+      :pagination="{ clickable: true }"
+      :loop="true"
+      :autoplay="{ delay: 3000, disableOnInteraction: false }"
+      class="stats-swiper"
   >
-    <SwiperSlide v-for="(item, index) in statsData" :key="index">
+    <SwiperSlide v-for="(item, index) in slides" :key="index">
       <div class="stats-container">
         <!-- 누적 포인트 슬라이드 -->
-        <div v-if="item.points" class="points-container">
-          <div class="points-number">{{ item.points.toLocaleString() }}</div>
+        <div v-if="item.kind === 'points'" class="points-container">
+          <div class="points-number">{{ formatNumber(item.value) }}</div>
           <div class="points-label">포인트</div>
         </div>
 
-        <!-- 기존 통계 슬라이드 -->
+        <!-- 요약 통계 슬라이드 -->
         <div v-else class="stats-content">
           <div class="stat-item">
             <div class="stat-number">{{ item.total }}</div>
@@ -44,16 +39,45 @@
 </template>
 
 <script setup>
-import { Swiper, SwiperSlide } from 'swiper/vue';
-import { Pagination, Autoplay } from 'swiper/modules';
+import {computed} from 'vue';
+import {Swiper, SwiperSlide} from 'swiper/vue';
+import {Pagination, Autoplay} from 'swiper/modules';
 import 'swiper/css';
 import 'swiper/css/pagination';
 
-// 더미 통계 데이터 (슬라이드 여러 개로 만들고 싶을 경우)
-const statsData = [
-  { total: 10, success: 8, rate: 80 },
-  { points: 1250 }, // 누적 포인트 슬라이드
-];
+/**
+ * props
+ * summary: { totalChallenges, successCount, achievementRate }
+ * points: number | null (월별 누적 포인트)
+ */
+const props = defineProps({
+  summary: {
+    type: Object,
+    default: () => ({totalChallenges: 0, successCount: 0, achievementRate: 0}),
+  },
+  points: {
+    type: [Number, null],
+    default: null,
+  },
+});
+
+const slides = computed(() => {
+  const arr = [];
+  // 1) 요약 슬라이드
+  arr.push({
+    kind: 'summary',
+    total: props.summary.totalChallenges ?? 0,
+    success: props.summary.successCount ?? 0,
+    rate: Math.round(props.summary.achievementRate ?? 0),
+  });
+  // 2) 포인트 슬라이드 (API가 값 줄 때만 표시)
+  if (props.points != null) {
+    arr.push({kind: 'points', value: Number(props.points) || 0});
+  }
+  return arr;
+});
+
+const formatNumber = (n) => Number(n || 0).toLocaleString();
 </script>
 
 <style scoped>
@@ -102,7 +126,6 @@ const statsData = [
   background: #e0e0e0;
 }
 
-/* 누적 포인트 스타일 */
 .points-container {
   display: flex;
   flex-direction: row;
@@ -131,7 +154,6 @@ const statsData = [
   align-items: center;
 }
 
-/* Swiper pagination 커스터마이징 */
 :deep(.swiper-pagination) {
   bottom: 0;
   position: relative;

--- a/src/components/challenge/HotChallengeCard.vue
+++ b/src/components/challenge/HotChallengeCard.vue
@@ -68,6 +68,7 @@ const formatDate = (dateString) => {
 
 // 카테고리 이름 반환 함수
 const getCategoryName = (categoryId) => {
+  if (props.challenge?.categoryName) return props.challenge.categoryName;
   const categories = {
     1: '전체 소비',
     2: '식비',

--- a/src/components/challenge/ParticipatingChallengeCard.vue
+++ b/src/components/challenge/ParticipatingChallengeCard.vue
@@ -66,6 +66,10 @@ const formatDate = (dateString) => {
 
 // 카테고리 이름 반환 함수
 const getCategoryName = (categoryId) => {
+  // 서버가 categoryName을 내려주면 그걸 우선 사용
+  if (props.challenge?.categoryName) return props.challenge.categoryName;
+
+  // (구) local dummy 대비 호환
   const categories = {
     1: '전체 소비',
     2: '식비',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -464,4 +464,25 @@ const router = createRouter({
   ],
 });
 
+import { useAuthStore } from '@/stores/auth';
+
+router.beforeEach(async (to) => {
+  const publicPages = new Set([
+    'Login','Signup','SignupComplete',
+    'ProfileStep1','ProfileStep2','ProfileStep3','ProfileStep4',
+    'ProfileStep5','ProfileStep6','ProfileStep7','ProfileStep8','ProfileStep9',
+    'ARSAuth','ArsVerification','ArsComplete','ArsFail'
+  ]);
+
+  const auth = useAuthStore();
+
+  // 보호 라우트면 먼저 조용히 AT 복구 시도
+  if (!publicPages.has(to.name)) {
+    await auth.bootstrap();
+    if (!auth.isAuthenticated) {
+      return { name: 'Login', query: { redirect: to.fullPath } };
+    }
+  }
+});
+
 export default router;

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -1,10 +1,7 @@
-// src/stores/auth.js
 import { defineStore } from 'pinia';
-import Cookies from 'js-cookie';
-// import api from '@/api'; // axios instance
-import { loginApi, refreshApi } from '@/api/authApi'; // API 함수들 import
-// 필요 시 라우터로 이동하려면 아래 임포트
-import router from '@/router'; // 라우터 경로 맞춰서
+import { loginApi } from '@/api/authApi';
+import router from '@/router';
+import api from '@/api/instance';
 
 export const useAuthStore = defineStore('auth', {
   state: () => ({
@@ -12,64 +9,69 @@ export const useAuthStore = defineStore('auth', {
     user: null,
     loading: false,
     error: null,
+    _bootstrapped: false, // 새로고침 직후 1회만 조용히 리프레시 시도
   }),
   getters: {
     isAuthenticated: (s) => !!s.accessToken,
   },
   actions: {
-    setTokens({ accessToken, refreshToken }) {
+    // RT는 httpOnly 쿠키로만 운용 → JS에서 만지지 않음
+    setTokens({ accessToken }) {
       this.accessToken = accessToken || null;
-      if (refreshToken) {
-        // 보안: 실제로는 서버가 httpOnly 쿠키로 내려주는 게 베스트.
-        Cookies.set('refreshToken', refreshToken, {
-          sameSite: 'lax',
-          secure: true,
-        });
-      }
     },
     clearTokens() {
       this.accessToken = null;
-      Cookies.remove('refreshToken');
     },
+
+    // 로그인: AT는 응답 헤더로, RT는 httpOnly 쿠키로 온다 (axios 응답 인터셉터가 AT 저장)
     async login({ email, password }) {
       try {
         this.loading = true;
         this.error = null;
 
-        const { data } = await loginApi(email, password);
-        // 서버 포맷: { status, message, data: { accessToken, refreshToken, user? } }
-        if (data?.data?.accessToken) {
-          this.setTokens({
-            accessToken: data.data.accessToken,
-            refreshToken: data.data.refreshToken,
-          });
-          this.user = data.data.user ?? null;
-          return true;
-        } else {
-          throw new Error(data?.message || '로그인 실패');
-        }
+        const res = await loginApi(email, password);
+        const payload = res.data?.data;
+        this.user = payload?.user ?? null; // 사용자 정보만 동기화
+        return true;
       } catch (err) {
-        this.error =
-          err.response?.data?.message || err.message || '로그인 실패';
+        this.error = err?.response?.data?.message || err?.message || '로그인 실패';
         return false;
       } finally {
         this.loading = false;
       }
     },
-    async refreshTokens() {
-      const refreshToken = Cookies.get('refreshToken');
-      if (!refreshToken) throw new Error('리프레시 토큰 없음');
 
-      const { data } = await refreshApi(refreshToken);
-      if (!data?.data?.accessToken) {
-        throw new Error(data?.message || '토큰 재발급 실패');
+    /**
+     * 앱 부팅/새로고침 직후, 조용히 /auth/refresh 한 번 호출해서 AT를 복구
+     * - 성공: 응답 인터셉터가 AT를 저장 → isAuthenticated=true
+     * - 실패: 아무 것도 하지 않음 (라우터 가드가 로그인으로 리다이렉트)
+     */
+    async bootstrap() {
+      if (this._bootstrapped) return;
+      this._bootstrapped = true;
+      try {
+        await api.post('/auth/refresh'); // 바디 없음, 쿠키 자동 전송(withCredentials)
+        // AT 저장은 응답 인터셉터(src/api/instance.js)가 처리
+      } catch {
+        // RT 만료/불일치면 조용히 실패
       }
-      this.setTokens({
-        accessToken: data.data.accessToken,
-        refreshToken: data.data.refreshToken, // 서버가 새로 주면 교체
-      });
-      return data.data.accessToken;
     },
+
+    /**
+     * (선택) 수동 리프레시가 필요할 때 호출 가능
+     */
+    async refreshTokens() {
+      try {
+        const res = await api.post('/auth/refresh');
+        const ok = !!res.headers?.authorization;
+        if (!ok) throw new Error('리프레시 응답에 Authorization 헤더 없음');
+        return res.headers.authorization.slice(7);
+      } catch (e) {
+        this.logout();
+        throw e;
+      }
+    },
+
     logout() {
       this.clearTokens();
       this.user = null;


### PR DESCRIPTION
## 챌린지
챌린지 홈 쪽 API 연동
- 챌린지 진행 사항 조회
- 월별 누적 포인트 조회
- 모집 중인 리스트 조회 (내가 참여 안 하고 있는)
- 참여 중인 리스트 조회 (모집 중 상태, 진행 중 상태)

## 토큰
쿠키 활용하도록 수정
토큰 재발급 구현
자동 로그인 구현