### PR TITLE
add: 챌린지 상세, 결과, 홈탭 및 생성 수정

### DIFF
--- a/src/api/challenge/challenge.js
+++ b/src/api/challenge/challenge.js
@@ -13,3 +13,19 @@ export const getChallengeList = (params = {}) =>
     api.get('/challenge/list', { params })
         .then(res => res.data?.data)           // List<ChallengeListResponseDTO>
         .catch(err => { throw err; });
+
+// 상세 조회
+export const getChallengeDetail = (id) =>
+    api.get(`/challenge/${id}`).then((res) => res.data?.data);
+
+// 참여하기 (비밀번호가 필요하면 { password } 전달)
+export const joinChallenge = (id, payload = {}) =>
+    api.post(`/challenge/${id}/join`, payload).then((res) => res.data?.data);
+
+// 결과 조회 (완료 + 미확인 시)
+export const getChallengeResult = (id) =>
+    api.get(`/challenge/${id}/result`).then((res) => res.data?.data);
+
+// 결과 확인 처리
+export const confirmChallengeResult = (id) =>
+    api.patch(`/challenge/${id}/result/confirm`).then((res) => res.data?.data);

--- a/src/api/coin/coin.js
+++ b/src/api/coin/coin.js
@@ -1,3 +1,4 @@
+// src/api/coin/coin.js
 import api from '../instance';
 
 /**
@@ -8,8 +9,19 @@ import api from '../instance';
 export const getMonthlyPoints = ({ year, month }) =>
     api
         .get('/coin/monthly', { params: { year, month } })
-        // res.data => CommonResponseDTO
-        // res.data.data => { month, amount, updatedAt }
+        .then((res) => res?.data?.data)
+        .catch((err) => {
+            throw err;
+        });
+
+/**
+ * 코인 스냅샷(잔액/일반누적/월누적/업데이트시각)
+ * 백엔드: GET /api/coin/status
+ * 응답: CommonResponseDTO<{ amount, cumulativeAmount, monthlyCumulativeAmount, updatedAt }>
+ */
+export const getCoinStatus = () =>
+    api
+        .get('/coin/status')
         .then((res) => res?.data?.data)
         .catch((err) => {
             throw err;

--- a/src/components/avatar/AvatarStack.vue
+++ b/src/components/avatar/AvatarStack.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="avatar-stack" :style="{ width: sizePx, height: sizePx }">
+    <template v-if="layerUrls.length">
+      <img
+          v-for="(url, i) in layerUrls"
+          :key="i"
+          :src="url"
+          class="layer"
+          loading="lazy"
+          decoding="async"
+          alt=""
+      />
+    </template>
+    <div v-else class="fallback">{{ initial }}</div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  levelId: Number,
+  topId: Number,
+  shoesId: Number,
+  accessoryId: Number,
+  giftCardId: Number,
+  nickname: String,
+  size: {type: Number, default: 56}, // 썸네일 한 변(px)
+});
+
+// S3 베이스 (고정)
+const S3_BASE = 'https://finpickbucket.s3.ap-northeast-2.amazonaws.com';
+
+// 폴더 구조
+const DIR = {
+  accessory: 'accessory',
+  giftCard: 'giftCard',
+  level: 'level',
+  shoes: 'shoes',
+  top: 'top',
+};
+
+// ===== 맵핑 =====
+// 레벨 (levelId → 하위 디렉터리/파일)
+const LEVEL_MAP = {
+  1: `${DIR.level}/SEEDLING/sprout.png`,   // 금융새싹
+  2: `${DIR.level}/TRAINEE/beginner.png`,  // 금융견습
+  3: `${DIR.level}/WIZARD/wizardhat.png`,  // 금융법사
+  4: `${DIR.level}/MASTER/dosa.png`,       // 금융도사
+};
+
+// 액세서리 (accessoryId → 파일)
+const ACCESSORY_MAP = {
+  1: `${DIR.accessory}/blush.png`,         // 블러셔
+  2: `${DIR.accessory}/sunglasses.png`,    // 선글라스
+};
+
+// 상의/신발/기프트카드: 실제 파일명에 맞게 추가해 주세요.
+const TOP_MAP = {
+  // 예) 1: `${DIR.top}/hoodie.png`,
+};
+const SHOES_MAP = {
+  // 예) 1: `${DIR.shoes}/sneakers.png`,
+};
+const GIFT_CARD_MAP = {
+  // 예) 1: `${DIR.giftCard}/gift.png`,
+};
+
+const makeUrl = (path) => `${S3_BASE}/${path}`;
+
+const layerUrls = computed(() => {
+  const arr = [];
+  // 레이어 순서: 레벨(베이스) → 상의 → 신발 → 액세서리 → 기프트카드
+  if (props.levelId && LEVEL_MAP[props.levelId]) arr.push(makeUrl(LEVEL_MAP[props.levelId]));
+  if (props.topId && TOP_MAP[props.topId]) arr.push(makeUrl(TOP_MAP[props.topId]));
+  if (props.shoesId && SHOES_MAP[props.shoesId]) arr.push(makeUrl(SHOES_MAP[props.shoesId]));
+  if (props.accessoryId && ACCESSORY_MAP[props.accessoryId]) arr.push(makeUrl(ACCESSORY_MAP[props.accessoryId]));
+  if (props.giftCardId && GIFT_CARD_MAP[props.giftCardId]) arr.push(makeUrl(GIFT_CARD_MAP[props.giftCardId]));
+  return arr;
+});
+
+const sizePx = computed(() => props.size + 'px');
+const initial = computed(() => (props.nickname || '?').slice(0, 1));
+</script>
+
+<style scoped>
+.avatar-stack {
+  position: relative;
+  border-radius: 50%;
+  overflow: hidden;
+  background: #f1f3f5;
+}
+
+.layer {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain; /* 원형 안에 자연스럽게 */
+}
+
+.fallback {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: #666;
+}
+</style>

--- a/src/components/challenge/ChallengeSuccessModal.vue
+++ b/src/components/challenge/ChallengeSuccessModal.vue
@@ -1,19 +1,17 @@
 <template>
   <div v-if="isVisible" class="modal-overlay" @click="handleOverlayClick">
     <div class="modal-content" @click.stop>
-      <!-- 제목 -->
       <h2 class="modal-title">챌린지 성공🎉</h2>
-      <!-- 성공 아이콘 -->
+
       <div class="success-icon">
         <i class="fas fa-trophy"></i>
       </div>
 
-      <!-- 챌린지 정보 -->
       <div class="challenge-info">
         <h3 class="challenge-title">
-          <span class="highlight-amount"
-            >{{ challengeResult.savedAmount.toLocaleString() }}원</span
-          >을 아꼈어요
+          <span class="highlight-amount">
+            {{ Number(challengeResult?.savedAmount || 0).toLocaleString() }}원
+          </span>을 아꼈어요
         </h3>
         <p class="success-description">
           축하합니다! 챌린지 목표를 달성했습니다.<br />
@@ -21,53 +19,33 @@
         </p>
       </div>
 
-      <!-- 보상 정보 -->
-
-      <div class="stock-card">
+      <!-- 추천 주식 (있을 때만) -->
+      <div v-if="challengeResult?.stockRecommendation" class="stock-card">
         <div class="stock-header">
           <div class="stock-info">
-            <h5 class="stock-name">
-              {{ challengeResult.stockRecommendation.stockName }}
-            </h5>
-            <p class="stock-code">
-              {{ challengeResult.stockRecommendation.stockCode }}
-            </p>
+            <h5 class="stock-name">{{ challengeResult.stockRecommendation.stockName }}</h5>
+            <p class="stock-code">{{ challengeResult.stockRecommendation.stockCode }}</p>
           </div>
           <div class="stock-price">
-            <span class="current-price"
-              >{{
-                challengeResult.stockRecommendation.currentPrice.toLocaleString()
-              }}원</span
-            >
-            <span
-              class="price-change"
-              :class="{
-                positive: challengeResult.stockRecommendation.priceChange > 0,
-                negative: challengeResult.stockRecommendation.priceChange < 0,
-              }"
-            >
-              {{ challengeResult.stockRecommendation.priceChange > 0 ? '+' : ''
-              }}{{
-                challengeResult.stockRecommendation.priceChange.toLocaleString()
-              }}원 ({{
-                challengeResult.stockRecommendation.priceChangeRate > 0
-                  ? '+'
-                  : ''
-              }}{{
-                challengeResult.stockRecommendation.priceChangeRate.toFixed(2)
-              }}%)
+            <span class="current-price">
+              {{ Number(challengeResult.stockRecommendation.stockPrice || 0).toLocaleString() }}원
+            </span>
+            <span v-if="challengeResult.stockRecommendation.stockChangeRate" class="price-change">
+              {{ challengeResult.stockRecommendation.stockChangeRate }}
             </span>
           </div>
         </div>
+        <p v-if="challengeResult.stockRecommendation.stockSummary" class="stock-summary">
+          {{ challengeResult.stockRecommendation.stockSummary }}
+        </p>
       </div>
-      <!-- 보상 정보 -->
 
+      <!-- 보상 정보 -->
       <div class="reward-card">
         <i class="fas fa-coins"></i>
-        <span>{{ challengeResult.actualRewardPoint }} 포인트 보상</span>
+        <span>{{ Number(challengeResult?.actualRewardPoint || 0).toLocaleString() }} 포인트 보상</span>
       </div>
 
-      <!-- 액션 버튼들 -->
       <div class="modal-actions">
         <button class="btn btn-secondary" @click="closeModal">
           <i class="fas fa-times"></i>
@@ -83,45 +61,21 @@
 
 <script setup>
 import { useRouter } from 'vue-router';
-
 const router = useRouter();
 
 const props = defineProps({
-  isVisible: {
-    type: Boolean,
-    default: false,
-  },
-  challenge: {
-    type: Object,
-    default: () => ({
-      title: '매일 5천원 저축하기',
-      description: '매일 5천원씩 저축하여 30일 동안 15만원 모으기',
-      targetAmount: 150000,
-      currentAmount: 150000,
-      duration: 30,
-    }),
-  },
-  challengeResult: {
-    type: Object,
-    default: () => ({
-      resultType: 'SUCCESS_WIN',
-      actualRewardPoint: 110,
-      savedAmount: 450000,
-      stockRecommendation: null,
-    }),
-  },
+  isVisible: { type: Boolean, default: false },
+  // ✅ 예시 기본값 제거, 실제 API 결과만 받도록 강제
+  challengeResult: { type: Object, required: true },
 });
 
 const emit = defineEmits(['close']);
-
-const closeModal = () => {
-  emit('close');
-};
-
+const closeModal = () => emit('close');
 const goToNextChallenge = () => {
   closeModal();
   router.push('/challenge/recruiting-list');
 };
+const handleOverlayClick = () => closeModal();
 </script>
 
 <style scoped>
@@ -283,6 +237,10 @@ const goToNextChallenge = () => {
 .price-change.negative {
   color: var(--color-danger);
 }
+
+.stock-summary { margin-top: 8px; color: #666; font-size: 13px; }
+.price-change { font-size: 14px; font-weight: 500; }
+.current-price { font-size: 20px; font-weight: bold; color: var(--color-main); }
 
 .modal-actions {
   display: flex;

--- a/src/pages/challenge/ChallengeCommonDetail.vue
+++ b/src/pages/challenge/ChallengeCommonDetail.vue
@@ -1,54 +1,64 @@
 <template>
   <div class="challenge-common-detail">
-    <!-- 챌린지 실패 모달 -->
+    <!-- 결과 모달 -->
+    <ChallengeSuccessModal
+        v-if="showSuccessModal && challengeResult"
+        :isVisible="showSuccessModal"
+        :challengeResult="challengeResult"
+        @close="handleResultConfirm"
+    />
     <ChallengeFailModal
-      :isVisible="showFailModal"
-      :challengeTitle="challenge?.title || ''"
-      :progressRate="challenge?.myProgress || 0"
-      :goalValue="challenge?.goalValue || 0"
-      @close="showFailModal = false"
-      @retry="handleRetry"
+        v-if="showFailModal"
+        :isVisible="showFailModal"
+        @close="handleResultConfirm"
     />
 
-    <!-- 챌린지 참여 확인 모달 -->
+    <!-- 참여 확인/완료 모달 -->
     <ChallengeJoinConfirmModal
-      :isVisible="showJoinConfirmModal"
-      :challenge="challenge"
-      @close="closeJoinConfirmModal"
-      @confirm="confirmJoin"
+        :isVisible="showJoinModal"
+        :challenge="challenge"
+        :mode="joinModalMode"
+        @close="closeJoinModal"
+        @confirm="confirmJoin"
     />
 
-    <!-- 로딩 상태 -->
+    <!-- 로딩 -->
     <div v-if="loading" class="loading-container">
       <div class="loading-spinner"></div>
       <p class="loading-text">챌린지 정보를 불러오는 중...</p>
     </div>
 
-    <!-- 챌린지 상세 정보 -->
+    <!-- 본문 -->
     <div v-else-if="challenge" class="content">
-      <!-- 챌린지 기본 정보 -->
+      <!-- 카테고리 뱃지 -->
+      <div
+          class="category-chip"
+          :style="{
+          background: categoryTheme.bg,
+          boxShadow: '0 6px 16px ' + categoryTheme.shadow
+        }"
+      >
+        {{ displayCategory }}
+      </div>
+
       <div class="challenge-info">
         <div class="title-section">
           <h1 class="challenge-title">{{ challenge.title }}</h1>
           <div class="challenge-date">
-            {{ formatDate(challenge.startDate) }} ~
-            {{ formatDate(challenge.endDate) }}
+            {{ formatDate(challenge.startDate) }} ~ {{ formatDate(challenge.endDate) }}
           </div>
         </div>
+
         <p class="challenge-description">{{ challenge.description }}</p>
 
         <div class="challenge-stats">
           <div class="stat-item">
             <span class="stat-label">진행률</span>
-            <span class="stat-value"
-              >{{ Math.round(challenge.myProgress * 100) }}%</span
-            >
+            <span class="stat-value">{{ Math.round((challenge.myProgress || 0) * 100) }}%</span>
           </div>
           <div class="stat-item">
             <span class="stat-label">목표 {{ challenge.goalType }}</span>
-            <span class="stat-value"
-              >{{ challenge.goalValue.toLocaleString() }}원</span
-            >
+            <span class="stat-value">{{ (challenge.goalValue || 0).toLocaleString() }}원</span>
           </div>
           <div class="stat-item">
             <span class="stat-label">남은 기간</span>
@@ -59,38 +69,27 @@
         <div class="progress-section" v-if="challenge.isParticipating">
           <div class="progress-header">
             <span class="progress-label">달성률</span>
-            <span class="progress-percentage"
-              >{{ Math.round(challenge.myProgress * 100) }}%</span
-            >
+            <span class="progress-percentage">{{ Math.round((challenge.myProgress || 0) * 100) }}%</span>
           </div>
           <div class="progress-bar">
-            <div
-              class="progress-fill"
-              :style="{
-                width: Math.round(challenge.myProgress * 100) + '%',
-              }"
-            ></div>
+            <div class="progress-fill" :style="{ width: Math.round((challenge.myProgress || 0) * 100) + '%' }"></div>
           </div>
         </div>
 
-        <!-- 참여자 수 표시 -->
         <div class="participants-section">
           <div class="participants-count">
-            <span class="participants-number">{{
-              challenge.participantsCount.toLocaleString()
-            }}</span>
+            <span class="participants-number">{{ (challenge.participantsCount || 0).toLocaleString() }}</span>
             <span class="participants-label">명 참여중</span>
           </div>
         </div>
       </div>
 
-      <!-- 참여 버튼 -->
-      <div class="join-section" v-if="!challenge.isParticipating">
-        <button class="join-button" @click="handleJoin">챌린지 참여하기</button>
+      <div class="join-section" v-if="!challenge.isParticipating && challenge.status === 'RECRUITING'">
+        <button class="join-button" @click="openJoinModal">챌린지 참여하기</button>
       </div>
     </div>
 
-    <!-- 에러 상태 -->
+    <!-- 에러 -->
     <div v-else class="error-container">
       <p class="error-text">챌린지 정보를 불러올 수 없습니다.</p>
     </div>
@@ -98,116 +97,153 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
-import challengeCommonDetailData from './challenge_common_detail.json';
+import { ref, onMounted, computed } from 'vue';
+import { useRoute } from 'vue-router';
+import { getChallengeDetail, joinChallenge, getChallengeResult, confirmChallengeResult } from '@/api/challenge/challenge.js';
 import ChallengeFailModal from '@/components/challenge/ChallengeFailModal.vue';
+import ChallengeSuccessModal from '@/components/challenge/ChallengeSuccessModal.vue';
 import ChallengeJoinConfirmModal from '@/components/challenge/ChallengeJoinConfirmModal.vue';
 
 const route = useRoute();
-const router = useRouter();
 
-// 상태 관리
 const loading = ref(true);
 const challenge = ref(null);
+
+// join modal
+const showJoinModal = ref(false);
+const joinModalMode = ref('confirm');
+
+// result modals
+const showSuccessModal = ref(false);
 const showFailModal = ref(false);
-const showJoinConfirmModal = ref(false);
+const challengeResult = ref(null); // ✅ 실제 결과 보관
 
-// 챌린지 데이터 fetch 함수
-const fetchChallenge = async (challengeId) => {
+const fetchDetail = async () => {
+  loading.value = true;
   try {
-    loading.value = true;
+    const id = route.params.id;
+    const data = await getChallengeDetail(id);
+    challenge.value = data;
 
-    // 라우터 state에서 전달받은 챌린지 데이터 확인
-    if (route.state && route.state.challengeData) {
-      challenge.value = route.state.challengeData;
+    // 완료 + 미확인 → 결과 모달 표시
+    if (data?.status === 'COMPLETED' && data?.isParticipating && !data?.isResultCheck) {
+      const result = await getChallengeResult(id);
+      challengeResult.value = result || null;
+
+      if (result?.resultType?.startsWith('SUCCESS')) showSuccessModal.value = true;
+      else showFailModal.value = true;
     } else {
-      // 실제로는 API 호출
-      // const response = await fetch(`/api/challenges/${challengeId}`);
-      // const data = await response.json();
-
-      // JSON 파일에서 데이터 가져오기 (실제로는 API에서 가져올 데이터)
-      const data = challengeCommonDetailData.data;
-      challenge.value = data;
+      showSuccessModal.value = false;
+      showFailModal.value = false;
+      challengeResult.value = null;
     }
-
-    // 사용자의 참여 여부는 challenge.isParticipating에서 직접 확인
-  } catch (error) {
-    console.error('챌린지 데이터 로드 실패:', error);
+  } catch (e) {
+    console.error(e);
     challenge.value = null;
   } finally {
     loading.value = false;
   }
 };
 
-onMounted(() => {
-  // URL 파라미터에서 챌린지 ID 가져오기
-  const challengeId = route.params.id;
+onMounted(fetchDetail);
 
-  // 챌린지 데이터 fetch
-  fetchChallenge(challengeId);
-});
-
-const formatDate = (dateString) => {
-  const date = new Date(dateString);
-  return date.toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
+const openJoinModal = () => {
+  joinModalMode.value = 'confirm';
+  showJoinModal.value = true;
 };
 
-// 남은 일수 계산 함수
+const closeJoinModal = () => {
+  showJoinModal.value = false;
+};
+
+const confirmJoin = async () => {
+  try {
+    await joinChallenge(route.params.id);
+    joinModalMode.value = 'success';
+  } catch (e) {
+    alert(e?.response?.data?.message || '참여에 실패했어요.');
+    showJoinModal.value = false;
+  }
+};
+
+const handleResultConfirm = async () => {
+  try {
+    await confirmChallengeResult(route.params.id);
+  } catch (_) {}
+  showSuccessModal.value = false;
+  showFailModal.value = false;
+  challengeResult.value = null;
+  await fetchDetail();
+};
+
+const formatDate = (d) => {
+  if (!d) return '';
+  const date = new Date(d);
+  return date.toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' });
+};
+
 const getRemainingDays = () => {
   if (!challenge.value?.endDate) return 0;
-  const endDate = new Date(challenge.value.endDate);
+  const end = new Date(challenge.value.endDate);
   const today = new Date();
-  const diffTime = endDate - today;
-  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  const diffDays = Math.ceil((end - today) / (1000 * 60 * 60 * 24));
   return Math.max(0, diffDays);
 };
 
-// checkParticipationStatus 함수 제거 - challenge.isParticipating을 직접 사용
-
-const handleJoin = () => {
-  // 이미 참여 중인지 확인
-  if (challenge.value.isParticipating) {
-    alert('이미 참여 중인 챌린지입니다.');
-    return;
-  }
-
-  // 참여 확인 모달 표시
-  showJoinConfirmModal.value = true;
+/* ---------- 카테고리 뱃지 ---------- */
+const CATEGORY_FALLBACK_BY_ID = {
+  1: '전체 소비 줄이기',
+  2: '식비 줄이기',
+  3: '카페·간식 줄이기',
+  4: '교통비 줄이기',
+  5: '미용·쇼핑 줄이기',
 };
 
-const confirmJoin = () => {
-  // 실제로는 API 호출로 참여 처리
-  challenge.value.isParticipating = true;
+const categoryKey = computed(() => {
+  const name = challenge.value?.categoryName || CATEGORY_FALLBACK_BY_ID[challenge.value?.categoryId];
+  if (!name) return 'default';
+  if (name.includes('전체')) return 'total';
+  if (name.includes('식비')) return 'food';
+  if (name.includes('카페') || name.includes('간식')) return 'snack';
+  if (name.includes('교통')) return 'transport';
+  if (name.includes('미용') || name.includes('쇼핑')) return 'beauty';
+  return 'default';
+});
 
-  // 모달 닫기
-  showJoinConfirmModal.value = false;
+const displayCategory = computed(() =>
+    challenge.value?.categoryName || CATEGORY_FALLBACK_BY_ID[challenge.value?.categoryId] || '카테고리'
+);
 
-  // 참여 중인 챌린지 상세 페이지로 이동 (공통 챌린지 상세)
-  const challengeId = route.params.id;
-  router.push(`/challenge/common-detail/${challengeId}`);
-};
-
-const closeJoinConfirmModal = () => {
-  showJoinConfirmModal.value = false;
-};
-
-const handleRetry = () => {
-  // 챌린지 재도전 로직
-  console.log('챌린지 재도전');
-  showFailModal.value = false;
-  // 여기에 재도전 로직 추가
-};
+const categoryTheme = computed(() => {
+  const map = {
+    total:     { bg: 'linear-gradient(135deg,#6C5CE7,#8E7CFF)', shadow: 'rgba(108,92,231,.3)' },
+    food:      { bg: 'linear-gradient(135deg,#F0932B,#F5A623)', shadow: 'rgba(240,147,43,.3)' },
+    snack:     { bg: 'linear-gradient(135deg,#FF7675,#FF9AA2)', shadow: 'rgba(255,118,117,.3)' },
+    transport: { bg: 'linear-gradient(135deg,#00B894,#55EFC4)', shadow: 'rgba(0,184,148,.3)' },
+    beauty:    { bg: 'linear-gradient(135deg,#0984E3,#74B9FF)', shadow: 'rgba(9,132,227,.3)' },
+    default:   { bg: 'linear-gradient(135deg,var(--color-main),var(--color-main-dark))', shadow: 'rgba(102,51,204,.28)' },
+  };
+  return map[categoryKey.value] || map.default;
+});
 </script>
+
 
 <style scoped>
 .challenge-common-detail {
   min-height: 100vh;
   background-color: #f8f9fa;
+}
+
+/* 카테고리 뱃지 */
+.category-chip{
+  align-self: flex-start;
+  color: #fff;
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: .2px;
+  padding: 8px 12px;
+  border-radius: 9999px;
+  margin-bottom: 12px;
 }
 
 .content {

--- a/src/pages/challenge/ChallengeGroupDetail.vue
+++ b/src/pages/challenge/ChallengeGroupDetail.vue
@@ -1,42 +1,64 @@
 <template>
   <div class="challenge-group-detail">
-    <!-- 챌린지 참여 확인 모달 -->
+    <!-- 참여 확인/완료 모달 -->
     <ChallengeJoinConfirmModal
-      :isVisible="showJoinConfirmModal"
-      :challenge="challenge"
-      @close="closeJoinConfirmModal"
-      @confirm="confirmJoin"
+        :isVisible="showJoinModal"
+        :challenge="challenge"
+        :mode="joinModalMode"
+        @close="closeJoinModal"
+        @confirm="confirmJoin"
     />
 
-    <!-- 로딩 상태 -->
+    <!-- 결과 모달들 (완료 + 미확인 진입 시) -->
+    <ChallengeSuccessModal
+        v-if="showSuccessModal && challengeResult"
+        :isVisible="showSuccessModal"
+        :challengeResult="challengeResult"
+        @close="handleResultConfirm"
+    />
+    <ChallengeFailModal
+        v-if="showFailModal"
+        :isVisible="showFailModal"
+        @close="handleResultConfirm"
+    />
+
+    <!-- 로딩 -->
     <div v-if="loading" class="loading-container">
       <div class="loading-spinner"></div>
       <p class="loading-text">챌린지 정보를 불러오는 중...</p>
     </div>
 
-    <!-- 챌린지 상세 정보 -->
+    <!-- 본문 -->
     <div v-else-if="challenge" class="content">
-      <!-- 챌린지 기본 정보 -->
+      <!-- 카테고리 뱃지 -->
+      <div
+          class="category-chip"
+          :style="{
+          background: categoryTheme.bg,
+          boxShadow: '0 6px 16px ' + categoryTheme.shadow
+        }"
+      >
+        {{ displayCategory }}
+      </div>
+
       <div class="challenge-info">
         <div class="title-section">
           <h1 class="challenge-title">{{ challenge.title }}</h1>
           <div class="challenge-date">
-            {{ formatDate(challenge.startDate) }} ~
-            {{ formatDate(challenge.endDate) }}
+            {{ formatDate(challenge.startDate) }} ~ {{ formatDate(challenge.endDate) }}
           </div>
         </div>
+
         <p class="challenge-description">{{ challenge.description }}</p>
 
         <div class="challenge-stats">
           <div class="stat-item">
             <span class="stat-label">참여자</span>
-            <span class="stat-value">{{ challenge.participantsCount }}명</span>
+            <span class="stat-value">{{ (challenge.participantsCount || 0) }}명</span>
           </div>
           <div class="stat-item">
             <span class="stat-label">목표 {{ challenge.goalType }}</span>
-            <span class="stat-value"
-              >{{ challenge.goalValue.toLocaleString() }}원</span
-            >
+            <span class="stat-value">{{ (challenge.goalValue || 0).toLocaleString() }}원</span>
           </div>
           <div class="stat-item">
             <span class="stat-label">남은 기간</span>
@@ -44,81 +66,73 @@
           </div>
         </div>
 
+        <!-- 내 진행률 (참여중일 때만) -->
         <div class="progress-section" v-if="challenge.isParticipating">
           <div class="progress-header">
             <span class="progress-label">달성률</span>
-            <span class="progress-percentage"
-              >{{ Math.round(challenge.myProgress * 100) }}%</span
-            >
+            <span class="progress-percentage">{{ Math.round((challenge.myProgress || 0) * 100) }}%</span>
           </div>
           <div class="progress-bar">
-            <div
-              class="progress-fill"
-              :style="{
-                width: Math.round(challenge.myProgress * 100) + '%',
-              }"
-            ></div>
+            <div class="progress-fill" :style="{ width: Math.round((challenge.myProgress || 0) * 100) + '%' }"></div>
           </div>
         </div>
 
-        <!-- 모집 인원 progress bar (참여하지 않을 때만 표시) -->
-        <div class="recruitment-section" v-if="!challenge.isParticipating">
+        <!-- 모집 현황 (미참여 & 모집중일 때) -->
+        <div class="recruitment-section" v-if="!challenge.isParticipating && isRecruiting">
           <div class="progress-header">
             <span class="progress-label">모집 현황</span>
-            <span class="progress-percentage"
-              >{{ challenge.participantsCount }}/6명</span
-            >
+            <span class="progress-percentage">{{ challenge.participantsCount }}/{{ maxParticipants }}명</span>
           </div>
           <div class="progress-bar">
-            <div
-              class="progress-fill"
-              :style="{
-                width: (challenge.participantsCount / 6) * 100 + '%',
-              }"
-            ></div>
+            <div class="progress-fill" :style="{ width: Math.min(100, ((challenge.participantsCount || 0) / maxParticipants) * 100) + '%' }"></div>
           </div>
         </div>
 
-        <!-- 참여자 목록 섹션 (참여 중일 때만 표시) -->
+        <!-- 참여자 목록 섹션 -->
         <div
-          class="members-section"
-          v-if="
-            challenge.isParticipating &&
-            challenge.members &&
-            challenge.members.length > 0
-          "
+            class="members-section"
+            v-if="challenge.isParticipating && challenge.members && challenge.members.length"
         >
-          <h3 class="members-title">참여자 목록</h3>
-          <div class="members-list">
-            <div
-              v-for="member in challenge.members"
-              :key="member.userId"
-              class="member-item"
-            >
-              <div class="member-info">
-                <span class="member-nickname">{{ member.nickname }}</span>
-                <span class="member-progress"
-                  >{{ Math.round(member.progress * 100) }}%</span
-                >
-              </div>
-              <div class="member-progress-bar">
-                <div
-                  class="member-progress-fill"
-                  :style="{ width: Math.round(member.progress * 100) + '%' }"
-                ></div>
+          <h3 class="members-title">참여자</h3>
+
+          <div class="avatar-grid">
+            <div v-for="m in challenge.members" :key="m.userId" class="avatar-card">
+              <AvatarStack
+                  :level-id="m.levelId"
+                  :top-id="m.topId"
+                  :shoes-id="m.shoesId"
+                  :accessory-id="m.accessoryId"
+                  :gift-card-id="m.giftCardId"
+                  :nickname="m.nickname"
+                  :size="56"
+              />
+              <div class="avatar-name" :title="m.nickname">{{ m.nickname }}</div>
+
+              <div class="avatar-progress">
+                <div class="avatar-progress-bar">
+                  <div
+                      class="avatar-progress-fill"
+                      :style="{ width: Math.round((m.progress || 0) * 100) + '%' }"
+                  ></div>
+                </div>
+                <div class="avatar-progress-text">
+                  {{ Math.round((m.progress || 0) * 100) }}%
+                </div>
               </div>
             </div>
           </div>
+
+          <p v-if="!challenge.isParticipating" class="members-hint">참여 후 멤버들의 진행률이 표시돼요.</p>
         </div>
       </div>
 
-      <!-- 참여 버튼 (참여하지 않을 때만 표시) -->
-      <div class="join-section" v-if="!challenge.isParticipating">
-        <button class="join-button" @click="handleJoin">챌린지 참여하기</button>
+      <!-- 참여 버튼 -->
+      <div class="join-section" v-if="showJoinButton">
+        <button class="join-button" @click="openJoinModal">챌린지 참여하기</button>
       </div>
     </div>
 
-    <!-- 에러 상태 -->
+    <!-- 에러 -->
     <div v-else class="error-container">
       <p class="error-text">챌린지 정보를 불러올 수 없습니다.</p>
     </div>
@@ -126,115 +140,195 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
-import challengeGroupDetailData from './challenge_group_detail.json';
+import { ref, onMounted, computed } from 'vue';
+import { useRoute } from 'vue-router';
+import { getChallengeDetail, joinChallenge, getChallengeResult, confirmChallengeResult } from '@/api/challenge/challenge.js';
 import ChallengeJoinConfirmModal from '@/components/challenge/ChallengeJoinConfirmModal.vue';
+import ChallengeFailModal from '@/components/challenge/ChallengeFailModal.vue';
+import ChallengeSuccessModal from '@/components/challenge/ChallengeSuccessModal.vue';
+import AvatarStack from '@/components/avatar/AvatarStack.vue';
 
 const route = useRoute();
-const router = useRouter();
 
-// 상태 관리
 const loading = ref(true);
 const challenge = ref(null);
-const showJoinConfirmModal = ref(false);
 
-onMounted(() => {
-  // URL 파라미터에서 챌린지 ID 가져오기
-  const challengeId = route.params.id;
+// join modal
+const showJoinModal = ref(false);
+const joinModalMode = ref('confirm'); // 'confirm' | 'success'
 
-  // 챌린지 데이터 fetch
-  fetchChallenge(challengeId);
-});
+// result modals
+const showSuccessModal = ref(false);
+const showFailModal = ref(false);
+const challengeResult = ref(null); // ✅ 실제 결과 보관
 
-// 챌린지 데이터 fetch 함수
-const fetchChallenge = async (challengeId) => {
+// 백엔드가 주는 값 우선 사용
+const maxParticipants = computed(() => challenge.value?.maxParticipants ?? 6);
+
+const isRecruiting = computed(() => challenge.value?.status === 'RECRUITING');
+const isMine = computed(() => !!challenge.value?.isMine);
+const showJoinButton = computed(() =>
+    isRecruiting.value &&
+    !challenge.value?.isParticipating &&
+    !isMine.value &&
+    ((challenge.value?.participantsCount || 0) < maxParticipants.value)
+);
+
+const fetchDetail = async () => {
+  loading.value = true;
   try {
-    loading.value = true;
+    const id = route.params.id;
+    const data = await getChallengeDetail(id);
+    challenge.value = data;
 
-    // 라우터 state에서 전달된 데이터 확인
-    const stateData = router.currentRoute.value.state?.challengeData;
+    // 완료 + 미확인 → 결과 모달
+    if (data?.status === 'COMPLETED' && data?.isParticipating && !data?.isResultCheck) {
+      const result = await getChallengeResult(id);
+      challengeResult.value = result || null;
 
-    if (stateData) {
-      // 라우터 state에서 전달된 데이터 사용
-      challenge.value = {
-        ...challengeGroupDetailData.data,
-        isParticipating:
-          stateData.participating || stateData.isParticipating || false,
-      };
+      if (result?.resultType?.startsWith('SUCCESS')) showSuccessModal.value = true;
+      else showFailModal.value = true;
     } else {
-      // JSON 파일에서 데이터 가져오기 (실제로는 API에서 가져올 데이터)
-      const data = challengeGroupDetailData.data;
-      challenge.value = data;
+      showSuccessModal.value = false;
+      showFailModal.value = false;
+      challengeResult.value = null;
     }
-
-    console.log('챌린지 ID:', challengeId);
-    console.log('챌린지 데이터:', challenge.value);
-    console.log('라우터 state:', router.currentRoute.value.state);
-
-    // 사용자의 참여 여부는 challenge.isParticipating에서 직접 확인
-  } catch (error) {
-    console.error('챌린지 데이터 로드 실패:', error);
+  } catch (e) {
+    console.error(e);
     challenge.value = null;
   } finally {
     loading.value = false;
   }
 };
 
-const formatDate = (dateString) => {
-  const date = new Date(dateString);
-  return date.toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
+onMounted(fetchDetail);
+
+const openJoinModal = () => {
+  joinModalMode.value = 'confirm';
+  showJoinModal.value = true;
 };
 
-// checkParticipationStatus 함수 제거 - challenge.isParticipating을 직접 사용
+const closeJoinModal = () => {
+  showJoinModal.value = false;
+};
 
-const handleJoin = () => {
-  // 참여 인원 마감 확인
-  if (challenge.value.participantsCount >= 6) {
-    alert('참여 인원이 마감되었습니다.');
-    return;
+const confirmJoin = async () => {
+  try {
+    await joinChallenge(route.params.id); // 비번 필요시 { password } 전달
+    joinModalMode.value = 'success';
+  } catch (e) {
+    alert(e?.response?.data?.message || '참여에 실패했어요.');
+    showJoinModal.value = false;
   }
-
-  // 참여 확인 모달 표시
-  showJoinConfirmModal.value = true;
 };
 
-const confirmJoin = () => {
-  // 실제로는 API 호출로 참여 처리
-  challenge.value.isParticipating = true;
-  challenge.value.participantsCount += 1;
-
-  // 모달 닫기
-  showJoinConfirmModal.value = false;
-
-  // 그룹 챌린지 상세 페이지로 이동 (참여 후)
-  const challengeId = route.params.id;
-  router.push(`/challenge/group-detail/${challengeId}`);
+const handleResultConfirm = async () => {
+  try {
+    await confirmChallengeResult(route.params.id);
+  } catch (_) {}
+  showSuccessModal.value = false;
+  showFailModal.value = false;
+  challengeResult.value = null;
+  await fetchDetail();
 };
 
-const closeJoinConfirmModal = () => {
-  showJoinConfirmModal.value = false;
+const formatDate = (d) => {
+  if (!d) return '';
+  const date = new Date(d);
+  return date.toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' });
 };
 
-// 남은 일수 계산 함수
 const getRemainingDays = () => {
+  if (!challenge.value?.endDate) return 0;
+  const end = new Date(challenge.value.endDate);
   const today = new Date();
-  const endDate = new Date(challenge.value.endDate);
-  const diffTime = endDate.getTime() - today.getTime();
-  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  const diffDays = Math.ceil((end - today) / (1000 * 60 * 60 * 24));
   return Math.max(0, diffDays);
 };
+
+/* ---------- 카테고리 뱃지 ---------- */
+const CATEGORY_FALLBACK_BY_ID = {
+  1: '전체 소비 줄이기',
+  2: '식비 줄이기',
+  3: '카페·간식 줄이기',
+  4: '교통비 줄이기',
+  5: '미용·쇼핑 줄이기',
+};
+
+const categoryKey = computed(() => {
+  const name = challenge.value?.categoryName || CATEGORY_FALLBACK_BY_ID[challenge.value?.categoryId];
+  if (!name) return 'default';
+  if (name.includes('전체')) return 'total';
+  if (name.includes('식비')) return 'food';
+  if (name.includes('카페') || name.includes('간식')) return 'snack';
+  if (name.includes('교통')) return 'transport';
+  if (name.includes('미용') || name.includes('쇼핑')) return 'beauty';
+  return 'default';
+});
+
+const displayCategory = computed(() =>
+    challenge.value?.categoryName || CATEGORY_FALLBACK_BY_ID[challenge.value?.categoryId] || '카테고리'
+);
+
+const categoryTheme = computed(() => {
+  const map = {
+    total:     { bg: 'linear-gradient(135deg,#6C5CE7,#8E7CFF)', shadow: 'rgba(108,92,231,.3)' },
+    food:      { bg: 'linear-gradient(135deg,#F0932B,#F5A623)', shadow: 'rgba(240,147,43,.3)' },
+    snack:     { bg: 'linear-gradient(135deg,#FF7675,#FF9AA2)', shadow: 'rgba(255,118,117,.3)' },
+    transport: { bg: 'linear-gradient(135deg,#00B894,#55EFC4)', shadow: 'rgba(0,184,148,.3)' },
+    beauty:    { bg: 'linear-gradient(135deg,#0984E3,#74B9FF)', shadow: 'rgba(9,132,227,.3)' },
+    default:   { bg: 'linear-gradient(135deg,var(--color-main),var(--color-main-dark))', shadow: 'rgba(102,51,204,.28)' },
+  };
+  return map[categoryKey.value] || map.default;
+});
 </script>
 
 <style scoped>
-.challenge-group-detail {
-  min-height: 100vh;
-  background-color: #f8f9fa;
+/* 기존 스타일 + 아바타 그리드 추가 */
+.challenge-group-detail { min-height: 100vh; background-color: #f8f9fa; }
+
+/* 카테고리 뱃지 */
+.category-chip{
+  align-self: flex-start;
+  color: #fff;
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: .2px;
+  padding: 8px 12px;
+  border-radius: 9999px;
+  margin-bottom: 12px;
 }
+
+.avatar-grid{
+  display:grid;
+  grid-template-columns: repeat(3, minmax(0,1fr));
+  gap:12px;
+}
+.avatar-card{
+  background:#f8f9fa;
+  border-radius:12px;
+  padding:12px;
+  text-align:center;
+}
+
+.avatar-name {
+  font-size: 12px;
+  color: #333;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  margin-top: 8px;
+}
+
+.avatar-progress { margin-top: 6px; }
+.avatar-progress-bar {
+  height: 6px; background-color: #e0e0e0; border-radius: 3px; overflow: hidden;
+}
+.avatar-progress-fill {
+  height: 100%;
+  background: linear-gradient(to right, var(--color-main), var(--color-main-light));
+}
+.avatar-progress-text { font-size: 11px; color: #666; margin-top: 4px; }
+
+.members-hint{ margin-top:8px; font-size:12px; color:#888; }
 
 /* 로딩 스타일 */
 .loading-container {

--- a/src/pages/challenge/ChallengeHome.vue
+++ b/src/pages/challenge/ChallengeHome.vue
@@ -1,81 +1,47 @@
 <script setup>
-import {ref, computed, onMounted} from 'vue';
-import {useRouter} from 'vue-router';
+import { ref, computed, onMounted, watch } from 'vue';
+import { useRouter } from 'vue-router';
 import HotChallengeCard from '@/components/challenge/HotChallengeCard.vue';
 import ParticipatingChallengeCard from '@/components/challenge/ParticipatingChallengeCard.vue';
 import ChallengeStatsSwiper from '@/components/challenge/ChallengeStatsSwiper.vue';
-import {
-  getChallengeSummary,
-  getChallengeList,
-} from '@/api/challenge/challenge.js';
-import {getMonthlyPoints} from '@/api/coin/coin.js';
+import { getChallengeSummary, getChallengeList } from '@/api/challenge/challenge.js';
+import { getMonthlyPoints } from '@/api/coin/coin.js';
 
-import {useUserStore} from '@/stores/user';
-import {useAuthStore} from '@/stores/auth';
+import { useAuthStore } from '@/stores/auth';
+import { useChallengeStore } from '@/stores/challenge';
 
 const router = useRouter();
-const userStore = useUserStore();
 const auth = useAuthStore();
+const challengeStore = useChallengeStore();
 
-// 로딩/에러 상태
-const loading = ref({
-  summary: false,
-  participating: false,
-  hot: false,
-  points: false,
-});
-const error = ref({
-  summary: null,
-  participating: null,
-  hot: null,
-  points: null,
-});
+const loading = ref({ summary: false, participating: false, hot: false, points: false });
+const error = ref({ summary: null, participating: null, hot: null, points: null });
 
-// 데이터
-const summary = ref({
-  totalChallenges: 0,
-  successCount: 0,
-  achievementRate: 0,
-});
+const summary = ref({ totalChallenges: 0, successCount: 0, achievementRate: 0 });
 const participatingChallenges = ref([]);
 const hotChallenges = ref([]);
-const monthlyPoints = ref(null); // ★ 월별 누적 포인트
+const monthlyPoints = ref(null); // StatsSwiper용(월누적)
 
-// 닉네임 우선 표시(백엔드 키 NickName/nickname 모두 대응), 없으면 userName → '사용자'
 const displayName = computed(() => {
   const u = auth.user || {};
   return u.nickname || u.NickName || u.userName || '사용자';
 });
 
-// 이동 핸들러
 const handleParticipate = (challenge) => {
   router.push({
     name: 'ChallengeCommonDetail',
-    params: {id: challenge.id},
-    state: {previousPage: '/challenge'},
+    params: { id: challenge.id },
+    state: { previousPage: '/challenge' },
   });
 };
 
 const goDetail = (challenge) => {
-  if (challenge.type === 'COMMON') {
-    router.push({
-      name: 'ChallengeCommonDetail',
-      params: {id: challenge.id},
-      state: {previousPage: '/challenge'},
-    });
-  } else if (challenge.type === 'GROUP') {
-    router.push({
-      name: 'ChallengeGroupDetail',
-      params: {id: challenge.id},
-      state: {previousPage: '/challenge'},
-    });
-  } else if (challenge.type === 'PERSONAL') {
-    router.push({
-      name: 'ChallengePersonalDetail',
-      params: {id: challenge.id},
-      state: {previousPage: '/challenge'},
-    });
-  }
+  if (challenge.type === 'COMMON')
+    router.push({ name: 'ChallengeCommonDetail', params: { id: challenge.id }, state: { previousPage: '/challenge' } });
+  else if (challenge.type === 'GROUP')
+    router.push({ name: 'ChallengeGroupDetail', params: { id: challenge.id }, state: { previousPage: '/challenge' } });
+  else if (challenge.type === 'PERSONAL')
+    router.push({ name: 'ChallengePersonalDetail', params: { id: challenge.id }, state: { previousPage: '/challenge' } });
 };
 
 const handleCardClick = (payload) => {
@@ -83,20 +49,14 @@ const handleCardClick = (payload) => {
   goDetail(challenge);
 };
 
-// 초기 데이터 로드
 const fetchSummary = async () => {
   loading.value.summary = true;
   error.value.summary = null;
   try {
     const data = await getChallengeSummary();
-    summary.value = data || {
-      totalChallenges: 0,
-      successCount: 0,
-      achievementRate: 0,
-    };
+    summary.value = data || summary.value;
   } catch (e) {
-    error.value.summary =
-        e?.response?.data?.message || e.message || '요약 조회 실패';
+    error.value.summary = e?.response?.data?.message || e.message || '요약 조회 실패';
   } finally {
     loading.value.summary = false;
   }
@@ -106,11 +66,14 @@ const fetchParticipating = async () => {
   loading.value.participating = true;
   error.value.participating = null;
   try {
-    const list = await getChallengeList({participating: true});
+    const list = await getChallengeList({ participating: true });
     participatingChallenges.value = Array.isArray(list) ? list : [];
+    // 진행중 개수 갱신
+    challengeStore.updateCountsFromList(participatingChallenges.value);
   } catch (e) {
-    error.value.participating =
-        e?.response?.data?.message || e.message || '참여중 목록 조회 실패';
+    error.value.participating = e?.response?.data?.message || e.message || '참여중 목록 조회 실패';
+    participatingChallenges.value = [];
+    challengeStore.resetCounts();
   } finally {
     loading.value.participating = false;
   }
@@ -120,14 +83,10 @@ const fetchHot = async () => {
   loading.value.hot = true;
   error.value.hot = null;
   try {
-    const list = await getChallengeList({
-      status: 'RECRUITING',
-      participating: false,
-    });
+    const list = await getChallengeList({ status: 'RECRUITING', participating: false });
     hotChallenges.value = Array.isArray(list) ? list : [];
   } catch (e) {
-    error.value.hot =
-        e?.response?.data?.message || e.message || 'HOT 목록 조회 실패';
+    error.value.hot = e?.response?.data?.message || e.message || 'HOT 목록 조회 실패';
   } finally {
     loading.value.hot = false;
   }
@@ -139,13 +98,11 @@ const fetchMonthlyPoints = async () => {
   try {
     const now = new Date();
     const y = now.getFullYear();
-    const m = now.getMonth() + 1; // 1~12
-    const res = await getMonthlyPoints({year: y, month: m});
-    // 백엔드 응답: { month, amount, updatedAt }
-    monthlyPoints.value = (res?.amount ?? null); // 값 없으면 null → 슬라이드 숨김
+    const m = now.getMonth() + 1;
+    const res = await getMonthlyPoints({ year: y, month: m });
+    monthlyPoints.value = res?.amount ?? null; // ← 이건 월누적 카드용만 사용
   } catch (e) {
-    error.value.points =
-        e?.response?.data?.message || e.message || '포인트 조회 실패';
+    error.value.points = e?.response?.data?.message || e.message || '포인트 조회 실패';
     monthlyPoints.value = null;
   } finally {
     loading.value.points = false;
@@ -157,8 +114,15 @@ onMounted(async () => {
     fetchSummary(),
     fetchParticipating(),
     fetchHot(),
-    fetchMonthlyPoints(), // ★ 포인트도 병렬로 불러오기
+    fetchMonthlyPoints(),
+    // ✅ 잔액/누적/월누적 스냅샷은 Pinia에 적재
+    challengeStore.fetchCoinStatus(),
   ]);
+});
+
+// 참여중 목록 바뀌면 개수 재계산
+watch(participatingChallenges, (list) => {
+  challengeStore.updateCountsFromList(list || []);
 });
 </script>
 
@@ -171,17 +135,10 @@ onMounted(async () => {
         </div>
       </div>
 
-      <!-- 스와이퍼 -->
-      <ChallengeStatsSwiper :summary="summary" :points="monthlyPoints"/>
-      <div v-if="loading.summary" style="color: #fff; margin: 6px 20px 0">
-        요약 로딩중…
-      </div>
-      <div v-else-if="error.summary" style="color: #fff; margin: 6px 20px 0">
-        {{ error.summary }}
-      </div>
-      <div v-if="error.points" style="color: #fff; margin: 6px 20px 0">
-        {{ error.points }}
-      </div>
+      <ChallengeStatsSwiper :summary="summary" :points="monthlyPoints" />
+      <div v-if="loading.summary" style="color: #fff; margin: 6px 20px 0">요약 로딩중…</div>
+      <div v-else-if="error.summary" style="color: #fff; margin: 6px 20px 0">{{ error.summary }}</div>
+      <div v-if="error.points" style="color: #fff; margin: 6px 20px 0">{{ error.points }}</div>
     </div>
 
     <!-- 참여중인 챌린지 -->
@@ -194,9 +151,7 @@ onMounted(async () => {
       </div>
 
       <div v-if="loading.participating" class="challenges-scroll">로딩중…</div>
-      <div v-else-if="error.participating" class="challenges-scroll">
-        {{ error.participating }}
-      </div>
+      <div v-else-if="error.participating" class="challenges-scroll">{{ error.participating }}</div>
       <div v-else class="challenges-scroll">
         <ParticipatingChallengeCard
             v-for="c in participatingChallenges"
@@ -211,13 +166,11 @@ onMounted(async () => {
             participating: c.isParticipating,
             myProgressRate: c.myProgressRate ?? 0,
             participantsCount: c.participantsCount ?? 0,
-            isResultCheck: c.isResultCheck ?? false,
+            isResultCheck: c.isResultCheck ?? false
           }"
             @cardClick="handleCardClick"
         />
-        <div v-if="participatingChallenges.length === 0" class="empty-message">
-          참여중인 챌린지가 없어요.
-        </div>
+        <div v-if="participatingChallenges.length === 0" class="empty-message">참여중인 챌린지가 없어요.</div>
       </div>
     </div>
 
@@ -247,14 +200,12 @@ onMounted(async () => {
             participating: c.isParticipating,
             myProgressRate: c.myProgressRate ?? null,
             participantsCount: c.participantsCount ?? 0,
-            isResultCheck: c.isResultCheck ?? false,
+            isResultCheck: c.isResultCheck ?? false
           }"
             @participate="handleParticipate"
             @click="handleCardClick"
         />
-        <div v-if="hotChallenges.length === 0" class="empty-message">
-          모집 중인 챌린지가 없어요.
-        </div>
+        <div v-if="hotChallenges.length === 0" class="empty-message">모집 중인 챌린지가 없어요.</div>
       </div>
     </div>
   </div>

--- a/src/pages/challenge/ChallengePersonalDetail.vue
+++ b/src/pages/challenge/ChallengePersonalDetail.vue
@@ -1,36 +1,55 @@
 <template>
   <div class="challenge-personal-detail">
-    <!-- 로딩 상태 -->
+    <!-- 결과 모달들 -->
+    <ChallengeSuccessModal
+        v-if="showSuccessModal && challengeResult"
+        :isVisible="showSuccessModal"
+        :challengeResult="challengeResult"
+        @close="handleResultConfirm"
+    />
+    <ChallengeFailModal
+        v-if="showFailModal"
+        :isVisible="showFailModal"
+        @close="handleResultConfirm"
+    />
+
+    <!-- 로딩 -->
     <div v-if="loading" class="loading-container">
       <div class="loading-spinner"></div>
       <p class="loading-text">챌린지 정보를 불러오는 중...</p>
     </div>
 
-    <!-- 챌린지 상세 정보 -->
+    <!-- 본문 -->
     <div v-else-if="challenge" class="content">
-      <!-- 챌린지 기본 정보 -->
+      <!-- 카테고리 뱃지 -->
+      <div
+          class="category-chip"
+          :style="{
+          background: categoryTheme.bg,
+          boxShadow: '0 6px 16px ' + categoryTheme.shadow
+        }"
+      >
+        {{ displayCategory }}
+      </div>
+
       <div class="challenge-info">
         <div class="title-section">
           <h1 class="challenge-title">{{ challenge.title }}</h1>
           <div class="challenge-date">
-            {{ formatDate(challenge.startDate) }} ~
-            {{ formatDate(challenge.endDate) }}
+            {{ formatDate(challenge.startDate) }} ~ {{ formatDate(challenge.endDate) }}
           </div>
         </div>
+
         <p class="challenge-description">{{ challenge.description }}</p>
 
         <div class="challenge-stats">
           <div class="stat-item">
             <span class="stat-label">진행률</span>
-            <span class="stat-value"
-              >{{ Math.round(challenge.myProgress * 100) }}%</span
-            >
+            <span class="stat-value">{{ Math.round((challenge.myProgress || 0) * 100) }}%</span>
           </div>
           <div class="stat-item">
             <span class="stat-label">목표 {{ challenge.goalType }}</span>
-            <span class="stat-value"
-              >{{ challenge.goalValue.toLocaleString() }}원</span
-            >
+            <span class="stat-value">{{ (challenge.goalValue || 0).toLocaleString() }}원</span>
           </div>
           <div class="stat-item">
             <span class="stat-label">남은 기간</span>
@@ -41,43 +60,29 @@
         <div class="progress-section">
           <div class="progress-header">
             <span class="progress-label">{{ challenge.goalType }} 진행률</span>
-            <span class="progress-percentage"
-              >{{ Math.round(challenge.myProgress * 100) }}%</span
-            >
+            <span class="progress-percentage">{{ Math.round((challenge.myProgress || 0) * 100) }}%</span>
           </div>
           <div class="progress-bar">
-            <div
-              class="progress-fill"
-              :style="{
-                width: Math.round(challenge.myProgress * 100) + '%',
-              }"
-            ></div>
+            <div class="progress-fill" :style="{ width: Math.round((challenge.myProgress || 0) * 100) + '%' }"></div>
           </div>
         </div>
 
-        <!-- 개인 챌린지 특별 정보 -->
         <div class="personal-info">
           <div class="savings-info">
             <span class="savings-label">현재 {{ challenge.goalType }}</span>
-            <span class="savings-amount"
-              >{{
-                Math.round(
-                  challenge.goalValue * challenge.myProgress
-                ).toLocaleString()
-              }}원</span
-            >
+            <span class="savings-amount">
+              {{ Math.round((challenge.goalValue || 0) * (challenge.myProgress || 0)).toLocaleString() }}원
+            </span>
           </div>
           <div class="daily-goal">
             <span class="goal-label">목표 {{ challenge.goalType }}</span>
-            <span class="goal-amount"
-              >{{ challenge.goalValue.toLocaleString() }}원</span
-            >
+            <span class="goal-amount">{{ (challenge.goalValue || 0).toLocaleString() }}원</span>
           </div>
         </div>
       </div>
     </div>
 
-    <!-- 에러 상태 -->
+    <!-- 에러 -->
     <div v-else class="error-container">
       <p class="error-text">챌린지 정보를 불러올 수 없습니다.</p>
     </div>
@@ -85,81 +90,134 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
-import challengeDetailData from './challenge_personal_detail.json';
+import { ref, onMounted, computed } from 'vue';
+import { useRoute } from 'vue-router';
+import { getChallengeDetail, getChallengeResult, confirmChallengeResult } from '@/api/challenge/challenge.js';
+import ChallengeFailModal from '@/components/challenge/ChallengeFailModal.vue';
+import ChallengeSuccessModal from '@/components/challenge/ChallengeSuccessModal.vue';
 
 const route = useRoute();
-const router = useRouter();
 
-// 상태 관리
 const loading = ref(true);
 const challenge = ref(null);
 
-onMounted(() => {
-  // URL 파라미터에서 챌린지 ID 가져오기
-  const challengeId = route.params.id;
+const showSuccessModal = ref(false);
+const showFailModal = ref(false);
+const challengeResult = ref(null); // ✅ 실제 API 응답 보관
 
-  // 챌린지 데이터 fetch
-  fetchChallenge(challengeId);
-});
-
-// 챌린지 데이터 fetch 함수
-const fetchChallenge = async (challengeId) => {
+const fetchDetail = async () => {
+  loading.value = true;
   try {
-    loading.value = true;
+    const id = route.params.id;
+    const data = await getChallengeDetail(id);
+    challenge.value = data;
 
-    // 라우터 state에서 전달된 데이터 확인
-    const stateData = router.currentRoute.value.state?.challengeData;
+    // (1) 완료 + (2) 내가 참여중 + (3) 결과 미확인 → 진입 시 결과 모달 자동 표시
+    if (data?.status === 'COMPLETED' && data?.isParticipating && !data?.isResultCheck) {
+      const result = await getChallengeResult(id);
+      challengeResult.value = result || null;
 
-    if (stateData) {
-      // 라우터 state에서 전달된 데이터 사용
-      challenge.value = {
-        ...challengeDetailData.data,
-        isParticipating:
-          stateData.participating || stateData.isParticipating || false,
-      };
+      if (result?.resultType?.startsWith('SUCCESS')) {
+        showSuccessModal.value = true;
+      } else {
+        showFailModal.value = true;
+      }
     } else {
-      // JSON 파일에서 데이터 가져오기 (실제로는 API에서 가져올 데이터)
-      const data = challengeDetailData.data;
-      challenge.value = data;
+      // 자동 노출 조건 아니면 모달 숨김
+      showSuccessModal.value = false;
+      showFailModal.value = false;
+      challengeResult.value = null;
     }
-
-    console.log('챌린지 ID:', challengeId);
-    console.log('챌린지 데이터:', challenge.value);
-    console.log('라우터 state:', router.currentRoute.value.state);
-  } catch (error) {
-    console.error('챌린지 데이터 로드 실패:', error);
+  } catch (e) {
+    console.error('챌린지 상세 조회 실패', e);
     challenge.value = null;
   } finally {
     loading.value = false;
   }
 };
 
-const formatDate = (dateString) => {
-  const date = new Date(dateString);
-  return date.toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
+onMounted(fetchDetail);
+
+const handleResultConfirm = async () => {
+  try {
+    await confirmChallengeResult(route.params.id);
+  } catch (e) {
+    console.warn('결과 확인 실패(멱등 가능):', e?.message || e);
+  } finally {
+    showSuccessModal.value = false;
+    showFailModal.value = false;
+    challengeResult.value = null;
+    await fetchDetail(); // 최신 상태 반영
+  }
 };
 
-// 남은 일수 계산 함수
+const formatDate = (d) => {
+  if (!d) return '';
+  const date = new Date(d);
+  return date.toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' });
+};
+
 const getRemainingDays = () => {
-  if (!challenge.value.endDate) return 0;
-  const endDate = new Date(challenge.value.endDate);
+  if (!challenge.value?.endDate) return 0;
+  const end = new Date(challenge.value.endDate);
   const today = new Date();
-  const diffTime = endDate - today;
-  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  const diffDays = Math.ceil((end - today) / (1000 * 60 * 60 * 24));
   return Math.max(0, diffDays);
 };
+
+/* ---------- 카테고리 뱃지 ---------- */
+const CATEGORY_FALLBACK_BY_ID = {
+  1: '전체 소비 줄이기',
+  2: '식비 줄이기',
+  3: '카페·간식 줄이기',
+  4: '교통비 줄이기',
+  5: '미용·쇼핑 줄이기',
+};
+
+const categoryKey = computed(() => {
+  const name = challenge.value?.categoryName || CATEGORY_FALLBACK_BY_ID[challenge.value?.categoryId];
+  if (!name) return 'default';
+  if (name.includes('전체')) return 'total';
+  if (name.includes('식비')) return 'food';
+  if (name.includes('카페') || name.includes('간식')) return 'snack';
+  if (name.includes('교통')) return 'transport';
+  if (name.includes('미용') || name.includes('쇼핑')) return 'beauty';
+  return 'default';
+});
+
+const displayCategory = computed(() =>
+    challenge.value?.categoryName || CATEGORY_FALLBACK_BY_ID[challenge.value?.categoryId] || '카테고리'
+);
+
+const categoryTheme = computed(() => {
+  const map = {
+    total:     { bg: 'linear-gradient(135deg,#6C5CE7,#8E7CFF)', shadow: 'rgba(108,92,231,.3)' },
+    food:      { bg: 'linear-gradient(135deg,#F0932B,#F5A623)', shadow: 'rgba(240,147,43,.3)' },
+    snack:     { bg: 'linear-gradient(135deg,#FF7675,#FF9AA2)', shadow: 'rgba(255,118,117,.3)' },
+    transport: { bg: 'linear-gradient(135deg,#00B894,#55EFC4)', shadow: 'rgba(0,184,148,.3)' },
+    beauty:    { bg: 'linear-gradient(135deg,#0984E3,#74B9FF)', shadow: 'rgba(9,132,227,.3)' },
+    default:   { bg: 'linear-gradient(135deg,var(--color-main),var(--color-main-dark))', shadow: 'rgba(102,51,204,.28)' },
+  };
+  return map[categoryKey.value] || map.default;
+});
 </script>
 
 <style scoped>
 .challenge-personal-detail {
   min-height: 100vh;
   background-color: #f8f9fa;
+}
+
+/* 카테고리 뱃지 */
+.category-chip{
+  align-self: flex-start;
+  color: #fff;
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: .2px;
+  padding: 8px 12px;
+  border-radius: 9999px;
+  margin-bottom: 12px;
 }
 
 /* 로딩 스타일 */

--- a/src/stores/challenge.js
+++ b/src/stores/challenge.js
@@ -1,0 +1,64 @@
+// src/stores/challenge.js
+import { defineStore } from 'pinia';
+import { getCoinStatus } from '@/api/coin/coin';
+
+export const useChallengeStore = defineStore('challenge', {
+    state: () => ({
+        // 진행 중 개수 (RECRUITING / IN_PROGRESS / COMPLETED & !isResultCheck)
+        counts: { PERSONAL: 0, GROUP: 0 },
+
+        // 포인트/코인 스냅샷
+        points: {
+            userPoints: 0,               // 잔액(amount)
+            cumulativeAmount: 0,         // 누적(cumulative_amount)
+            monthlyCumulativeAmount: 0,  // 월누적(monthly_cumulative_amount)
+            updatedAt: null,             // 스냅샷 시각
+            required: { PERSONAL: 0, GROUP: 100, COMMON: 100 }, // 정책값
+        },
+    }),
+    getters: {
+        isTypeFull: (s) => (type) =>
+            ['PERSONAL', 'GROUP'].includes(type) ? s.counts[type] >= 3 : false,
+        isAllFull: (s) => s.counts.PERSONAL >= 3 && s.counts.GROUP >= 3,
+        canCreateByType: (s) => (type) =>
+            type === 'GROUP' ? s.counts.GROUP < 3 : type === 'PERSONAL' ? s.counts.PERSONAL < 3 : true,
+        hasEnoughPointsForType: (s) => (type) =>
+            s.points.userPoints >= (s.points.required[type] ?? 0),
+        lackPointsAmountForType: (s) => (type) =>
+            Math.max(0, (s.points.required[type] ?? 0) - s.points.userPoints),
+    },
+    actions: {
+        updateCountsFromList(list = []) {
+            const isActive = (c) =>
+                c &&
+                (c.status === 'RECRUITING' ||
+                    c.status === 'IN_PROGRESS' ||
+                    (c.status === 'COMPLETED' && c.isResultCheck === false));
+            this.counts.PERSONAL = list.filter((c) => c.type === 'PERSONAL' && isActive(c)).length;
+            this.counts.GROUP = list.filter((c) => c.type === 'GROUP' && isActive(c)).length;
+        },
+        resetCounts() {
+            this.counts.PERSONAL = 0;
+            this.counts.GROUP = 0;
+        },
+        setUserPoints(p) {
+            // (호환용) 필요한 곳에서 임시 세팅할 때 사용 가능
+            this.points.userPoints = Number(p) || 0;
+        },
+        setRequiredPoints(map) {
+            this.points.required = { ...this.points.required, ...map };
+        },
+        async fetchCoinStatus() {
+            try {
+                const snap = await getCoinStatus();
+                this.points.userPoints = Number(snap?.amount ?? 0);
+                this.points.cumulativeAmount = Number(snap?.cumulativeAmount ?? 0);
+                this.points.monthlyCumulativeAmount = Number(snap?.monthlyCumulativeAmount ?? 0);
+                this.points.updatedAt = snap?.updatedAt ?? null;
+            } catch (e) {
+                // 실패해도 앱은 계속 동작: 기본값 유지
+                this.points.userPoints = this.points.userPoints || 0;
+            }
+        },
+    },
+});


### PR DESCRIPTION
# 📌 Pull Request

**제목 예시:** \[Challenge] 결과 조회/확인 API 완전 연동 + 더미 제거 (Personal/Group/Common)

## 👀 작업 요약

* 챌린지 **결과 조회/확인 전 과정(API 연동)** 적용
* 예시 데이터(더미 props) **전면 제거** → **실제 응답 바인딩**
* Personal / Group / Common 상세 페이지 모두 동일 패턴으로 통합
* 성공/실패 모달 노출 조건 및 멱등 확인 로직 정리

## 📖 작업 내용

### 1) 페이지별 연동

* **Personal**

  * `GET /challenge/{id}/detail` 로 초기 데이터 로딩
  * (완료 + 참여중 + 미확인) 진입 시 `GET /challenge/{id}/result` 호출 → 결과에 따라 성공/실패 모달
  * 모달 닫기 시 `PATCH /challenge/{id}/result/confirm` → 코인 적립 확정 → 상세 재조회
  * 파일: `src/pages/challenge/ChallengePersonalDetail.vue`

* **Group**

  * 위 Personal과 동일한 결과 모달 흐름 적용
  * 모집/참여 상태에 따른 UI 분기 유지
  * **maxParticipants**: 백엔드 값(`challenge.maxParticipants`) 우선, 없을 시 6 fallback
  * 파일: `src/pages/challenge/ChallengeGroupDetail.vue`

* **Common**

  * 위 Personal과 동일한 결과 모달 흐름 적용
  * 파일: `src/pages/challenge/ChallengeCommonDetail.vue`

### 2) 모달 컴포넌트 정리

* **ChallengeSuccessModal**

  * 더미 props **제거**
  * `challengeResult` **필수 prop**으로 변경 (`required: true`)
  * `savedAmount`, `actualRewardPoint`, `stockRecommendation` 안전 표기(옵셔널 체이닝 + `Number().toLocaleString()`)
  * 파일: `src/components/challenge/ChallengeSuccessModal.vue`

### 3) API 사용 지점

* `getChallengeDetail(id)` : 상세 데이터(참여 여부, 진행률, 상태 등)
* `getChallengeResult(id)` : 결과 계산 + DB 저장(성공/실패, finalReward, 추천 주식)
* `confirmChallengeResult(id)` : **코인 적립 확정 + 결과 확인 마킹**
* (Group/Common만) `joinChallenge(id[, { password }])` : 참여 플로우

### 4) 공통 처리/리팩토링

* 모달 노출 조건 통일: **`status === 'COMPLETED' && isParticipating && !isResultCheck`**
* 결과 모달 닫기 → **confirm → 재조회(fetchDetail)** 멱등 보장
* 숫자 표기/빈값 방어: `Number(value || 0).toLocaleString()` / optional chaining 도입
* 더미 데이터 제거로 **실 서비스 데이터만 렌더**

### 5) 영향 파일

* `src/pages/challenge/ChallengePersonalDetail.vue`
* `src/pages/challenge/ChallengeGroupDetail.vue`
* `src/pages/challenge/ChallengeCommonDetail.vue`
* `src/components/challenge/ChallengeSuccessModal.vue`
* (간접) `src/api/challenge/challenge.js` 사용

---

## ✅ 체크리스트

* [ ] 커밋 컨벤션 준수 (feat/fix/refactor 등 prefix, 한글/영문 설명 명확)
* [ ] 로컬 환경에서 동작 확인 완료

  * [ ] Personal/Group/Common 완료 상태 진입 시 결과 모달 정상 표출
  * [ ] `confirm` 호출 후 코인 반영/요약 수치 재계산 확인
  * [ ] 실패 케이스에서도 흐름 끊김 없음
* [ ] 리뷰어 n명 이상 승인 완료
* [ ] 문서화가 필요한 경우 추가했습니다.

  * README나 위키에 “결과 모달 노출 조건” 및 “confirm 멱등” 기록
* [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

---

## ✋ 질문 사항

* Group에서 `maxParticipants`가 백엔드에 항상 내려오나요? 누락 시 6으로 fallback 중인데, **백엔드 필드 보장 여부** 확인 부탁드립니다.
* 실패 모달에도 `actualRewardPoint`(항상 0) 표기할지 여부? 현재는 성공 모달만 보상 노출.
* 추천 주식이 없을 때(조건 미충족/빈 배열) 안내 문구 추가할까요? (예: “절약 금액이 1,000원 이하라 추천이 제공되지 않아요”)

---

## 🔗 관련 이슈

* closes #??? (챌린지 결과 연동)
* relates #??? (그룹 참여 UX)
* fixes #??? (더미 데이터 제거)

---

## 🧪 테스트 플랜 (수동 시나리오)

1. **성공/보상/추천 주식 노출**

   * 조건: 완료 + 참여중 + 미확인, `savedAmount > 1000`
   * 기대: 성공 모달 노출, `stockRecommendation` 카드 표시, 닫기 시 `confirm` 호출 → 코인 적립

2. **성공(동일)**

   * 조건: `actual == goal`
   * 기대: `SUCCESS_EQUAL` 모달(추천 없음), 닫기 → confirm → 재조회 후 `isResultCheck = true`

3. **실패**

   * 조건: `actual > goal`
   * 기대: 실패 모달 노출, 보상 0, 닫기 → confirm → 재조회

4. **추천 미표시 케이스**

   * 조건: `savedAmount <= 1000` 또는 추천가 전부 상한 초과
   * 기대: 성공 모달은 뜨되, 추천 카드 섹션은 비표시

5. **Group 참여 플로우**

   * 모집중 + 미참여 → 참여 버튼 클릭 → (비번 필요 시 입력) → 참여 성공
   * 기대: 참여자수 증가, 내 진행률/멤버 목록 표출

6. **멱등성**

   * 결과 모달 닫기 여러 번 클릭 / confirm API 중복 호출
   * 기대: 코인 중복 적립 없음, 서버에서 멱등 처리

7. **에러 처리**

   * `getChallengeResult` 실패 시: 콘솔 경고, 모달 미노출/페이지는 정상
   * 네트워크 에러 시: 에러 로그 확인, 페이지 복귀 가능

---

## 📡 API 계약(요약)

* `GET /challenge/{id}/detail` → `{ status, isParticipating, isResultCheck, myProgress, maxParticipants?, ... }`
* `GET /challenge/{id}/result` → `{ resultType: 'SUCCESS_WIN'|'SUCCESS_EQUAL'|'FAIL', actualRewardPoint, savedAmount, stockRecommendation? }`
* `PATCH /challenge/{id}/result/confirm` → 200 OK (멱등)
* `POST /challenge/{id}/join` (`{ password? }`) → 200 OK

> 참고: 추천 주식은 서버에서 OpenAI/키움 호출 후 결정. `stockRecommendation`가 없을 수 있음.

---

## ⚠️ 브레이킹 체인지

* `ChallengeSuccessModal`의 더미 props 제거 → **이제 반드시 `challengeResult`를 부모에서 전달해야 함**
* 기존에 더미에 의존해 렌더링하던 다른 페이지가 있다면 영향 받을 수 있으나, 본 PR에서는 Personal/Group/Common만 수정

---

## 🧩 접근성/UX

* 모달 포커스 트랩/ESC 닫기 미구현 (추가 이슈로 분리 제안)
* 숫자/날짜 표기 한국어 로캘 적용

---

## 🧰 환경 변수

* 프론트 변경분은 추가 env 없음
* (참고) 백엔드: `openai.api.key`, `openai.api.url` 필수 (이미 수정/배포 진행 중)

---

## 🗓️ 롤아웃/리스크/리버트

* **롤아웃**: 바로 배포 가능 (프론트만)
* **리스크**: 특정 상태 조합에서 모달 노출 조건 미일치 가능성 → QA 시나리오로 커버
* **리버트**: 문제가 생기면 이전 커밋으로 롤백 가능. 더미 props 복구 필요 없음(실데이터 경로 유지)

---

## 📷 스크린샷/레코딩

* [ ] Personal 결과 모달(성공/실패)
* [ ] Group 참여 전/후 화면 + 결과 모달
* [ ] Common 결과 모달